### PR TITLE
Updated default empty description for body params

### DIFF
--- a/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
+++ b/src/Extracting/Strategies/BodyParameters/GetFromBodyParamTag.php
@@ -69,7 +69,7 @@ class GetFromBodyParamTag extends Strategy
                     // this means only name and type were supplied
                     list($name, $type) = preg_split('/\s+/', $tag->getContent());
                     $required = false;
-                    $description = '';
+                    $description = ucfirst(implode(' ', explode('_', $name)));
                 } else {
                     list($_, $name, $type, $required, $description) = $content;
                     $description = trim($description);


### PR DESCRIPTION
It seems logical to me to take the default parameter names and explode them out to provide a default description. This way for a majority of fields no description has to be provided unless the user chooses to override this value.

Before:

![image](https://user-images.githubusercontent.com/2487374/90260865-0fa78280-de44-11ea-87ac-f2a4b8ab4171.png)


After:

![image](https://user-images.githubusercontent.com/2487374/90260902-1cc47180-de44-11ea-9586-774b1f7a175a.png)
